### PR TITLE
Added a check on the `alpha` argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,9 @@ const { hexToRGB, formatRGB, formatRGBA } = require("./utils");
 const hexAlpha = (input, alpha) => {
   const newColor = hexToRGB(input);
 
-  if (alpha !== undefined) {
-    return formatRGBA(newColor, alpha);
-  } else {
-    return formatRGB(newColor);
-  }
+  return alpha && typeof alpha === "number"
+    ? formatRGBA(newColor, alpha)
+    : formatRGB(newColor);
 };
 
 module.exports = hexAlpha;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const { hexToRGB, formatRGB, formatRGBA } = require("./utils");
 const hexAlpha = (input, alpha) => {
   const newColor = hexToRGB(input);
 
-  return alpha && typeof alpha === "number"
+  return alpha && typeof alpha === "number" && alpha >= 0 && alpha <= 1
     ? formatRGBA(newColor, alpha)
     : formatRGB(newColor);
 };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const { hexToRGB, formatRGB, formatRGBA } = require("./utils");
 const hexAlpha = (input, alpha) => {
   const newColor = hexToRGB(input);
 
-  return alpha && typeof alpha === "number" && alpha >= 0 && alpha <= 1
+  return typeof alpha === "number" && alpha >= 0 && alpha <= 1
     ? formatRGBA(newColor, alpha)
     : formatRGB(newColor);
 };

--- a/index.test.js
+++ b/index.test.js
@@ -12,14 +12,22 @@ test("#fa6d01 converts to rgb(250,109,1)", () => {
   expect(hexAlpha("#fa6d01")).toBe("rgb(250,109,1)");
 });
 
+test("#f00 converts to rgba(0,0,0,1)", () => {
+  expect(hexAlpha("#f00", 0.1)).toBe("rgba(255,0,0,0.1)");
+});
+
 test("HEX color and alpha converts to RGBA", () => {
   expect(hexAlpha("#fa6d01", 0.1)).toBe("rgba(250,109,1,0.1)");
 });
 
-test("HEX color with zero alpha converts to RGBA", () => {
+test("HEX color with 0 or 1 alpha converts to RGBA", () => {
   expect(hexAlpha("#fa6d01", 0)).toBe("rgba(250,109,1,0)");
+  expect(hexAlpha("#fa6d01", 1)).toBe("rgba(250,109,1,1)");
 });
 
-test("#f00 converts to rgba(0,0,0,1)", () => {
-  expect(hexAlpha("#f00", 0.1)).toBe("rgba(255,0,0,0.1)");
+test("HEX color with invalid `alpha` converts to RGB", () => {
+  expect(hexAlpha("#fa6d01", "")).toBe("rgb(250,109,1)");
+  expect(hexAlpha("#fa6d01", false)).toBe("rgb(250,109,1)");
+  expect(hexAlpha("#fa6d01", -1)).toBe("rgb(250,109,1)");
+  expect(hexAlpha("#fa6d01", 2.4)).toBe("rgb(250,109,1)");
 });

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ yarn add hex-alpha
 import hexAlpha from "hex-alpha";
 
 hexAlpha("#fa6d01", 0.1);
-// returns "rgba(250,109,1, 0.1)"
+// returns "rgba(250,109,1,0.1)"
 
 hexAlpha("#000000", 1);
 // returns "rgba(0,0,0,1)"
@@ -30,4 +30,5 @@ hexAlpha("#ffffff");
 ```
 
 ## Meetup talk
+
 I gave a talk about making HEX-Alpha at the Sydney Javascript meetup - SydJS. [Check it out here](https://www.youtube.com/watch?v=OQbF8Mx4iso).

--- a/utils.js
+++ b/utils.js
@@ -2,7 +2,7 @@
  * @param {string} input - A color in hexadecimal syntax. e.g. #fa6d01
  * @returns { R: string, G: string, B: string}
  */
-const hexToRGB = input => {
+const hexToRGB = (input) => {
   // normalising string
   const inputColor = input.replace("#", "").toLowerCase();
 
@@ -15,15 +15,15 @@ const hexToRGB = input => {
   let rgb = {
     R: inputColor.slice(0, slotWidth),
     G: inputColor.slice(slotWidth, 2 * slotWidth),
-    B: inputColor.slice(2* slotWidth, 3 * slotWidth)
+    B: inputColor.slice(2 * slotWidth, 3 * slotWidth),
   };
 
   // applying the algorithm
   // FF = (15 × 16¹) + (15 × 16⁰) = 255
   // input = (x × 16¹) + (y × 16⁰) = 255
   // input = (a) + (b) = 255
-  Object.keys(rgb).forEach(e => {
-    const channelValue = rgb[e]
+  Object.keys(rgb).forEach((e) => {
+    const channelValue = rgb[e];
     const x = isShorthand ? channelValue : channelValue.charAt(0); // first character of the color channel string
     const y = isShorthand ? channelValue : channelValue.charAt(1); // second character of the color channel string
 
@@ -40,22 +40,22 @@ const formatRGBA = (color, a) =>
   `rgba(${color.R},${color.G},${color.B},${color.A || a})`;
 
 const keys = {
-  "0": 0,
-  "1": 1,
-  "2": 2,
-  "3": 3,
-  "4": 4,
-  "5": 5,
-  "6": 6,
-  "7": 7,
-  "8": 8,
-  "9": 9,
+  0: 0,
+  1: 1,
+  2: 2,
+  3: 3,
+  4: 4,
+  5: 5,
+  6: 6,
+  7: 7,
+  8: 8,
+  9: 9,
   a: 10,
   b: 11,
   c: 12,
   d: 13,
   e: 14,
-  f: 15
+  f: 15,
 };
 
 module.exports = { hexToRGB, formatRGB, formatRGBA };


### PR DESCRIPTION
Added a check on `hexAlpha`'s second argument `alpha`, so that:

```javascript
hexAlpha("#fa6d01", "");
hexAlpha("#fa6d01", false);
hexAlpha("#fa6d01", -1);
hexAlpha("#fa6d01", 2.4);
```

will all ignore it and return: `rgb(250,109,1)`.